### PR TITLE
Fixed building on Linux (Ubuntu), with SDL 2.0.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 CXXFLAGS=-std=c++17 -Wall -Wpedantic -Wextra
-LIBS=-lSDLmain -lSDL2 -lSDL2_ttf -lSDL2_image
+LIBS=-lSDL2main -lSDL2 -lSDL2_ttf -lSDL2_image
 SRC_FILES=src/Input/Input.cpp src/Main.cpp src/Engine.cpp src/Rendering/Rendering.cpp src/Animation2D/Animation2D.cpp
 TEST_FILES=src/Input/Input_test.cpp src/Rendering/Rendering_test.cpp
 TEST_FLAG=WITH_TESTS
+UNAME_S=$(shell uname -s)
+
+ifeq ($(UNAME_S),Linux)
+LINUX_FLAG=-DLINUX
+endif
 
 build:
-	g++ $(SRC_FILES) $(CXXFLAGS) $(LIBS) -D$(TEST_FLAG)=false -o engine
+	g++ $(SRC_FILES) $(CXXFLAGS) $(LIBS) -D$(TEST_FLAG)=false $(LINUX_FLAG) -o engine
 
 tests:
-	g++ $(SRC_FILES) $(TEST_FILES) $(CXXFLAGS) $(LIBS) -D$(TEST_FLAG)=true -o engine-test
+	g++ $(SRC_FILES) $(TEST_FILES) $(CXXFLAGS) $(LIBS) -D$(TEST_FLAG)=true $(LINUX_FLAG) -o engine-test

--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -4,6 +4,11 @@
 #include <map>
 #include "Input.hpp"
 
+#if LINUX
+SDL_Joystick* SDL_JoystickFromPlayerIndex(int joystick) { return 0; }
+void SDL_GameControllerSetPlayerIndex(SDL_GameController* controller, int joystick) {}
+#endif
+
 bool Input::is_held(Sint32 a, bool with_controller, Sint32 controller) {
     const bool controller_down = with_controller ? this->controllers[controller].controller_held[a] : false;
     return controller_down || this->mouse_held[a] || this->key_held[a];


### PR DESCRIPTION
Since we use features from SDL 2.0.12, building on Ubuntu with SDL 2.0.10 from the standard repositories was broken.
I've added a macro to the Makefile which overwrites definitions of the missing SDL functions.